### PR TITLE
Recipeモデル関連の単体、アクセステストの実施

### DIFF
--- a/code/tests/Feature/ExampleTest.php
+++ b/code/tests/Feature/ExampleTest.php
@@ -4,10 +4,13 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Recipe;
 
 class ExampleTest extends TestCase
 {
-    /** */
+    /** 
+     * 事前マイグレートとRecipeのレコード作成
+    */
     protected function setUp(): void
     {
         parent::setUp();
@@ -15,17 +18,57 @@ class ExampleTest extends TestCase
         $this->artisan(
             'migrate --env=testing --database=sqlite_testing --force'
         );
+
+        $recipe = self::newSampleRecipe();
+        $recipe->save();
     }
 
     /**
-     * A basic test example.
+     * トップページが正常に表示されるかどうかのテスト
      *
      * @return void
      */
-    public function testBasicTest()
+    public function testToppageIsAvailable()
     {
         $response = $this->get('/');
 
         $response->assertStatus(200);
+    }
+
+    /**
+     * 指定したidのRecipeレコードがある時、レシピ詳細ページが正常に表示されるかどうかのテスト
+     *
+     * @return void
+     */
+    public function testShowRecipeIsAvailableWithRecord()
+    {
+        $recipe = Recipe::latest()->first();
+        $response = $this->get('/recipes/'.$recipe->id);
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 指定したidのRecipeレコードがない時、レシピ詳細ページが正常に表示されないことのテスト
+     *
+     * @return void
+     */
+    public function testShowRecipeIsNotAvailableWithoutRecord()
+    {
+        $recipe = Recipe::latest()->first();
+        $response = $this->get('/recipes/999');
+
+        $response->assertStatus(404);
+    }
+
+
+    /**
+     * Recipeのサンプルオブジェクトの生成
+     */
+    private static function newSampleRecipe(){
+        $recipe = new Recipe();
+        $recipe->title = "サンプルレシピ";
+        $recipe->description = "サンプル説明文";
+        return $recipe;
     }
 }

--- a/code/tests/Unit/RecipeTest.php
+++ b/code/tests/Unit/RecipeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Recipe;
+
+class RecipeTest extends TestCase
+{
+    /**
+     * 事前マイグレート
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan(
+            'migrate --env=testing --database=sqlite_testing --force'
+        );
+    }
+    /**
+     * タイトル、説明文があれば登録できる
+     */
+    public function testCreateRecipe()
+    {
+        $recipe = new Recipe();
+        $recipe->title = "サンプル";
+        $recipe->description = "サンプルレシピ";
+        $recipe->save();
+
+        $expected = 1;
+        $actual = Recipe::latest()->first()->id;
+
+        $this->assertSame($expected, $actual);
+    }
+
+}

--- a/code/tests/Unit/RecipeTest.php
+++ b/code/tests/Unit/RecipeTest.php
@@ -8,6 +8,7 @@ use App\Recipe;
 
 class RecipeTest extends TestCase
 {
+
     /**
      * 事前マイグレート
      */
@@ -19,6 +20,7 @@ class RecipeTest extends TestCase
             'migrate --env=testing --database=sqlite_testing --force'
         );
     }
+
     /**
      * タイトル、説明文があれば登録できる
      */
@@ -34,8 +36,9 @@ class RecipeTest extends TestCase
 
         $this->assertSame($expected, $actual);
     }
+
     /**
-     * 全てのカラムが空では登録できない
+     * 全てのカラムがnullでは登録できない
      */
     public function testNotCreateRecipe()
     {
@@ -43,6 +46,42 @@ class RecipeTest extends TestCase
 
         $recipe = new Recipe();
         $recipe->save();
+    }
+
+    /**
+     * 説明文があってもタイトルがnullでは登録できない
+     */
+    public function testCreateRecipeWithoutTitle(){
+        $this->expectException(QueryException::class);
+
+        $recipe = self::createSampleRecipe();
+        $recipe->title = null;
+
+        $recipe->save();
+    }
+
+    /**
+     * タイトルがあっても説明文がnullでは登録できない
+     */
+    public function testCreateRecipeWithoutDescription(){
+        $this->expectException(QueryException::class);
+
+        $recipe = self::createSampleRecipe();
+        $recipe->description = null;
+
+        $recipe->save();
+    }
+
+    /**
+     * testCreateRecipeの結果に基づき、
+     * 同じ内容のRecipeモデルオブジェクトを生成する関数
+     */
+    private static function createSampleRecipe(){
+        $recipe = new Recipe();
+        $recipe->title = "サンプル";
+        $recipe->description = "サンプルレシピ";
+
+        return $recipe;
     }
 
 }

--- a/code/tests/Unit/RecipeTest.php
+++ b/code/tests/Unit/RecipeTest.php
@@ -79,7 +79,7 @@ class RecipeTest extends TestCase
     public function testCreateRecipeWithUserId(){
         $recipe = self::createSampleRecipe();
 
-        $recipe->user_id = 1;
+        $recipe->user_id = 2;
         $recipe->save();
 
         $this->assertTrue(isset($recipe->id));
@@ -91,7 +91,7 @@ class RecipeTest extends TestCase
     public function testCreateRecipeWithMaingredId(){
         $recipe = self::createSampleRecipe();
 
-        $recipe->maingred_id = 1;
+        $recipe->maingred_id = 2;
         $recipe->save();
 
         $this->assertTrue(isset($recipe->id));
@@ -103,7 +103,7 @@ class RecipeTest extends TestCase
     public function testCreateRecipeWithMethodId(){
         $recipe = self::createSampleRecipe();
 
-        $recipe->method_id = 1;
+        $recipe->method_id = 2;
         $recipe->save();
 
         $this->assertTrue(isset($recipe->id));

--- a/code/tests/Unit/RecipeTest.php
+++ b/code/tests/Unit/RecipeTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use Tests\TestCase;
 use Illuminate\Database\QueryException;
 use App\Recipe;
+use App\User;
 
 class RecipeTest extends TestCase
 {
@@ -70,6 +71,42 @@ class RecipeTest extends TestCase
         $recipe->description = null;
 
         $recipe->save();
+    }
+
+    /**
+     * user_idが数字であれば登録できる
+     */
+    public function testCreateRecipeWithUserId(){
+        $recipe = self::createSampleRecipe();
+
+        $recipe->user_id = 1;
+        $recipe->save();
+
+        $this->assertTrue(isset($recipe->id));
+    }
+
+    /**
+     * maingred_idが数字であれば登録できる
+     */
+    public function testCreateRecipeWithMaingredId(){
+        $recipe = self::createSampleRecipe();
+
+        $recipe->maingred_id = 1;
+        $recipe->save();
+
+        $this->assertTrue(isset($recipe->id));
+    }
+
+    /**
+     * method_idが数字であれば登録できる
+     */
+    public function testCreateRecipeWithMethodId(){
+        $recipe = self::createSampleRecipe();
+
+        $recipe->method_id = 1;
+        $recipe->save();
+
+        $this->assertTrue(isset($recipe->id));
     }
 
     /**

--- a/code/tests/Unit/RecipeTest.php
+++ b/code/tests/Unit/RecipeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Tests\TestCase;
+use Illuminate\Database\QueryException;
 use App\Recipe;
 
 class RecipeTest extends TestCase
@@ -32,6 +33,16 @@ class RecipeTest extends TestCase
         $actual = Recipe::latest()->first()->id;
 
         $this->assertSame($expected, $actual);
+    }
+    /**
+     * 全てのカラムが空では登録できない
+     */
+    public function testNotCreateRecipe()
+    {
+        $this->expectException(QueryException::class);
+
+        $recipe = new Recipe();
+        $recipe->save();
     }
 
 }


### PR DESCRIPTION
・Recipeモデルへの単体テスト
・ログインをせずにアクセスできるRecipeController関連ページのアクセスステータスのテスト
(ログインをしないとアクセスできないページへのテストは別pull requestにて後ほど実施)