### PR TITLE
Recipeモデル関連の結合テストの実施

### DIFF
--- a/code/tests/Feature/ExampleTest.php
+++ b/code/tests/Feature/ExampleTest.php
@@ -9,7 +9,7 @@ use App\Recipe;
 class ExampleTest extends TestCase
 {
     /** 
-     * 事前マイグレートとRecipeのレコード作成
+    * 事前マイグレートとRecipeのレコード作成
     */
     protected function setUp(): void
     {
@@ -35,40 +35,4 @@ class ExampleTest extends TestCase
         $response->assertStatus(200);
     }
 
-    /**
-     * 指定したidのRecipeレコードがある時、レシピ詳細ページが正常に表示されるかどうかのテスト
-     *
-     * @return void
-     */
-    public function testShowRecipeIsAvailableWithRecord()
-    {
-        $recipe = Recipe::latest()->first();
-        $response = $this->get('/recipes/'.$recipe->id);
-
-        $response->assertStatus(200);
-    }
-
-    /**
-     * 指定したidのRecipeレコードがない時、レシピ詳細ページが正常に表示されないことのテスト
-     *
-     * @return void
-     */
-    public function testShowRecipeIsNotAvailableWithoutRecord()
-    {
-        $recipe = Recipe::latest()->first();
-        $response = $this->get('/recipes/999');
-
-        $response->assertStatus(404);
-    }
-
-
-    /**
-     * Recipeのサンプルオブジェクトの生成
-     */
-    private static function newSampleRecipe(){
-        $recipe = new Recipe();
-        $recipe->title = "サンプルレシピ";
-        $recipe->description = "サンプル説明文";
-        return $recipe;
-    }
 }

--- a/code/tests/Feature/ExampleTest.php
+++ b/code/tests/Feature/ExampleTest.php
@@ -35,4 +35,15 @@ class ExampleTest extends TestCase
         $response->assertStatus(200);
     }
 
+    /**
+     * Recipeのサンプルオブジェクトの生成
+     */
+    private static function newSampleRecipe(){
+        $recipe = new Recipe();
+        $recipe->title = "サンプルレシピ";
+        $recipe->description = "サンプル説明文";
+
+        return $recipe;
+    }
+
 }

--- a/code/tests/Feature/RecipeTest.php
+++ b/code/tests/Feature/RecipeTest.php
@@ -5,12 +5,14 @@ namespace Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
+use App\Recipe;
+use App\User;
 
 class RecipeTest extends TestCase
 {
 
     /** 
-     * 事前マイグレートとRecipeのレコード作成
+     * 事前マイグレートとサンプルユーザー、サンプルレシピの作成
     */
     protected function setUp(): void
     {
@@ -20,7 +22,9 @@ class RecipeTest extends TestCase
             'migrate --env=testing --database=sqlite_testing --force'
         );
 
-        $recipe = self::newSampleRecipe();
+        $user = self::newSampleUser();
+        $user->save();
+        $recipe = self::newSampleRecipe($user);
         $recipe->save();
     }
 
@@ -52,12 +56,32 @@ class RecipeTest extends TestCase
 
 
     /**
+     * private
+     */
+
+    /**
+     * サンプルユーザーの作成
+     */
+    private static function newSampleUser()
+    {
+        $user = new User();
+        $user->name = "サンプルユーザー";
+        $user->email = "sample@sample.com";
+        $user->password = "samplepassword";
+
+        return $user;
+    }
+
+    /**
      * Recipeのサンプルオブジェクトの生成
      */
-    private static function newSampleRecipe(){
+    private static function newSampleRecipe($user){
         $recipe = new Recipe();
         $recipe->title = "サンプルレシピ";
         $recipe->description = "サンプル説明文";
+        $recipe->user_id = $user->id;
+
         return $recipe;
     }
+
 }

--- a/code/tests/Feature/RecipeTest.php
+++ b/code/tests/Feature/RecipeTest.php
@@ -116,6 +116,45 @@ class RecipeTest extends TestCase
         $response->assertRedirect("/login");
     }
 
+    /**
+     * ログイン状態であれば、自分で作成したレシピの削除確認ページへアクセスできる
+     */
+    public function testAccessDestroyConfirmWithAuthor(){
+        $user = User::latest()->first();
+        $recipe = Recipe::where("id", $user->id)->first();
+
+        $response = $this->actingAs($user)
+                            ->withSession(["user_id" => $user->id])
+                            ->get('/recipes/'.$recipe->id.'/destroy');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * ログイン状態であっても、自分以外のユーザーが作成したレシピの削除確認ページへは403でアクセスできない
+     */
+    public function testCannotAccessDestroyConfirmWithNotAuthor(){
+        $user = User::latest()->first();
+        $recipe = self::createAnotherRecipe();
+
+        $response = $this->actingAs($user)
+                            ->withSession(["user_id" => $user->id])
+                            ->get('/recipes/'.$recipe->id.'/destroy');
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * 非ログイン状態では削除確認ページへアクセスできず、ログインページへリダイレクトされる
+     */
+    public function testCannotAccessDestroyConfirmWithoutUser(){
+        $recipe = Recipe::latest()->first();
+
+        $response = $this->get('/recipes/'.$recipe->id.'/destroy');
+
+        $response->assertRedirect("/login");
+    }
+
 
     /**
      * private

--- a/code/tests/Feature/RecipeTest.php
+++ b/code/tests/Feature/RecipeTest.php
@@ -78,6 +78,34 @@ class RecipeTest extends TestCase
     }
 
     /**
+     * ログイン状態であれば新規投稿機能を利用できる
+     */
+    public function testStoreRecipeWithUser(){
+        $user = User::latest()->first();
+        $formData = self::recipeFormData();
+
+        $response = $this->actingAs($user)
+                            ->withSession(["user_id" => $user->id])
+                            ->from("/recipes/create")
+                            ->post('/recipes', $formData);
+
+        $this->assertDatabaseHas("recipes", ["title"=>"サンプルレシピ３"]);
+
+        $response->assertStatus(302);
+    }
+
+    /**
+     * 非ログイン状態では新規投稿機能を利用できず、ログインページへリダイレクトされる
+     */
+    public function testCannotCreateRecipeWithoutUser(){
+        $formData = self::recipeFormData();
+
+        $response = $this->post('/recipes', $formData);
+
+        $response->assertRedirect("/login");
+    }
+
+    /**
      * ログイン状態であれば、自分で作成したレシピの編集ページへアクセスできる
      */
     public function testAccessEditRecipeWithAuthor(){

--- a/code/tests/Feature/RecipeTest.php
+++ b/code/tests/Feature/RecipeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class RecipeTest extends TestCase
+{
+
+    /** 
+     * 事前マイグレートとRecipeのレコード作成
+    */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan(
+            'migrate --env=testing --database=sqlite_testing --force'
+        );
+
+        $recipe = self::newSampleRecipe();
+        $recipe->save();
+    }
+
+    /**
+     * 指定したidのRecipeレコードがある時、レシピ詳細ページが正常に表示されるかどうかのテスト
+     *
+     * @return void
+     */
+    public function testShowRecipeIsAvailableWithRecord()
+    {
+        $recipe = Recipe::latest()->first();
+        $response = $this->get('/recipes/'.$recipe->id);
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 指定したidのRecipeレコードがない時、レシピ詳細ページが正常に表示されないことのテスト
+     *
+     * @return void
+     */
+    public function testShowRecipeIsNotAvailableWithoutRecord()
+    {
+        $recipe = Recipe::latest()->first();
+        $response = $this->get('/recipes/999');
+
+        $response->assertStatus(404);
+    }
+
+
+    /**
+     * Recipeのサンプルオブジェクトの生成
+     */
+    private static function newSampleRecipe(){
+        $recipe = new Recipe();
+        $recipe->title = "サンプルレシピ";
+        $recipe->description = "サンプル説明文";
+        return $recipe;
+    }
+}

--- a/code/tests/Feature/RecipeTest.php
+++ b/code/tests/Feature/RecipeTest.php
@@ -229,7 +229,7 @@ class RecipeTest extends TestCase
     }
 
     /**
-     * ログイン状態であれば、自分で作成したレシピの削除ページへアクセスできる
+     * ログイン状態であれば、自分で作成したレシピの削除機能を利用できる
      */
     public function testAccessDestroyRecipeWithAuthor(){
         $user = User::latest()->first();
@@ -245,7 +245,7 @@ class RecipeTest extends TestCase
     }
 
     /**
-     * ログイン状態であっても、自分以外のユーザーが作成したレシピの削除ページへは403でアクセスできない
+     * ログイン状態であっても、自分以外のユーザーが作成したレシピの削除機能は403で利用できない
      */
     public function testCannotAccessDestroyRecipeWithNotAuthor(){
         $user = User::latest()->first();
@@ -259,7 +259,7 @@ class RecipeTest extends TestCase
     }
 
     /**
-     * 非ログイン状態では削除確認ページへアクセスできず、ログインページへリダイレクトされる
+     * 非ログイン状態では削除機能を利用できず、ログインページへリダイレクトされる
      */
     public function testCannotAccessDestroyRecipeWithoutUser(){
         $recipe = Recipe::latest()->first();

--- a/code/tests/Feature/RecipeTest.php
+++ b/code/tests/Feature/RecipeTest.php
@@ -28,6 +28,7 @@ class RecipeTest extends TestCase
         $recipe->save();
     }
 
+
     /**
      * 指定したidのRecipeレコードがある時、レシピ詳細ページが正常に表示されるかどうかのテスト
      *
@@ -52,6 +53,28 @@ class RecipeTest extends TestCase
         $response = $this->get('/recipes/999');
 
         $response->assertStatus(404);
+    }
+
+    /**
+     * ログイン状態であれば新規投稿ページへアクセスできる
+     */
+    public function testAccessCreateRecipeWithUser(){
+        $user = User::latest()->first();
+
+        $response = $this->actingAs($user)
+                            ->withSession(["user_id" => $user->id])
+                            ->get('/recipes/create');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * 非ログイン状態では新規投稿ページへアクセスできず、ログインページへリダイレクトされる
+     */
+    public function testCannotAccessCreateRecipeWithoutUser(){
+        $response = $this->get('/recipes/create');
+
+        $response->assertRedirect("/login");
     }
 
 


### PR DESCRIPTION
## What
Recipeモデル関連ページのうち、  
利用にあたって認証が必要とされるページ、機能に関連するテストを実施
- 新規投稿ページへのアクセスと新規投稿機能実行について
「ログイン時」「非ログイン時」それぞれの挙動をテスト
- 編集ページへのアクセスと編集機能実行について
「ログイン時・自身の投稿」「ログイン時・他者の投稿」「非ログイン時」それぞれの挙動をテスト
- 削除確認ページ、削除機能実行について
編集と同じく「ログイン時・自身の投稿」「ログイン時・他者の投稿」「非ログイン時」の挙動をテスト
