### PR TITLE
ユーザー関連の不具合の修正

### DIFF
--- a/code/app/Exceptions/Handler.php
+++ b/code/app/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Session\TokenMismatchException;
 
 class Handler extends ExceptionHandler
 {
@@ -50,6 +51,10 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
+        if ($exception instanceof TokenMismatchException) {
+            return redirect('/login');
+        }
+
         return parent::render($request, $exception);
     }
 }

--- a/code/app/Http/Controllers/Auth/RegisterController.php
+++ b/code/app/Http/Controllers/Auth/RegisterController.php
@@ -50,9 +50,17 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'name' => [
+                'required', 'string', 'max:255'
+            ],
+            'email' => [
+                'required', 'string', 'email', 'max:255', 'unique:users',
+                'regex:/^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[@][a-zA-Z0-9]+[a-zA-Z0-9.-]*$/'
+            ],
+            'password' => [
+                'required', 'string', 'min:8', 'confirmed',
+                'regex:/[a-zA-Z0-9]+/'
+            ],
         ]);
     }
 

--- a/code/app/Http/Controllers/ExtraAuthController.php
+++ b/code/app/Http/Controllers/ExtraAuthController.php
@@ -6,6 +6,11 @@ use Illuminate\Http\Request;
 
 class ExtraAuthController extends Controller
 {
+
+    public function __construct(){
+        $this->middleware("auth")->only(["logout_confirm"]);
+    }
+
     /**
      * logout confirm
      */


### PR DESCRIPTION
## What
- セッション期限切れの状態でログアウトボタンを押した場合に発生していた419エラーへの対応
=> ログインページへリダイレクトされるよう修正
- URLを直打ちしたとしても非ログイン時にはログアウト確認ページを表示することが出来ないよう修正
=> こちらもログインページへリダイレクトされるよう設定
- ユーザー新規登録時のメールアドレス、パスワードに関するバリデーションの設定の見直し
=> 正規表現によるバリデーションの追加